### PR TITLE
chore: consolidate Dependabot dependency upgrades

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ marshmallow==3.26.2
 mypy_extensions==1.1.0
 packaging==25.0
 python-dotenv==1.0.1
-requests==2.32.3
+requests==2.32.4
 typing-inspect==0.9.0
 typing_extensions==4.13.2
 urllib3==2.6.3


### PR DESCRIPTION
## Summary

Consolidates all open Dependabot PRs (#3, #7, #8) into a single change.

- Bumps `requests` from `2.32.3` → `2.32.4` — fixes CVE-2024-47081 (netrc credential leak via maliciously crafted URL)
- `marshmallow` and `urllib3` were already updated to `3.26.2` and `2.6.3` respectively in #9, so those Dependabot PRs are superseded

Closes #3
Closes #7
Closes #8