### PR TITLE
fix: correct Optional typing and missing fields in Python response dataclasses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 .ropeproject
 **/.venv
+**/venv
 **/__pycache__
 **/node_modules
 .DS_Store

--- a/python/api/response.py
+++ b/python/api/response.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass
 from typing import List, Optional
 
@@ -271,7 +270,6 @@ class MeasureResponse(DataClassJsonMixin):
     rows: Optional[List[Row]] = None
 
     def __str__(self) -> str:
-        print(json.dumps(self.to_dict(), indent=2))
         return (
             f"RequestID: {self.requestId}\n"
             f"Total Emissions: {self.totalEmissions:.4f}\n"

--- a/python/api/response.py
+++ b/python/api/response.py
@@ -1,14 +1,18 @@
-from dataclasses import dataclass, field
+import json
+from dataclasses import dataclass
 from typing import List, Optional
-from dataclasses_json import DataClassJsonMixin, dataclass_json, config
+
+from dataclasses_json import DataClassJsonMixin, dataclass_json
+
 
 @dataclass_json
 @dataclass
 class AdFormats:
-    generic: int
     metric: str
+    generic: int
     unknown: int
     vendorSpecific: int
+
 
 @dataclass_json
 @dataclass
@@ -18,12 +22,15 @@ class Channels:
     modeled: int
     unknown: int
 
+
 @dataclass_json
 @dataclass
 class BaseMetric:
     metric: str
     modeled: int
     unknown: int
+    verifiedRate: Optional[float] = None
+
 
 @dataclass_json
 @dataclass
@@ -32,16 +39,18 @@ class TotalMetric:
     modeled: int
     skipped: int
 
+
 @dataclass_json
 @dataclass
 class Coverage:
-    adFormats: AdFormats
-    channels: Channels
-    mediaOwners: BaseMetric
-    properties: BaseMetric
-    sellers: BaseMetric
     totalImpressions: TotalMetric
     totalRows: TotalMetric
+    adFormats: Optional[AdFormats] = None
+    channels: Optional[Channels] = None
+    mediaOwners: Optional[BaseMetric] = None
+    properties: Optional[BaseMetric] = None
+    sellers: Optional[BaseMetric] = None
+
 
 @dataclass_json
 @dataclass
@@ -51,6 +60,7 @@ class Policy:
     policy: str
     policyOwner: str
 
+
 @dataclass_json
 @dataclass
 class RowPolicy:
@@ -58,12 +68,17 @@ class RowPolicy:
     policy: str
     policyOwner: str
 
+
 @dataclass_json
 @dataclass
 class EmissionsTotals:
-    adSelection: float
-    creativeDelivery: float
-    mediaDistribution: float
+    adSelection: Optional[float] = None
+    compensated: Optional[float] = None
+    creativeDelivery: Optional[float] = None
+    disposal: Optional[float] = None
+    mediaDistribution: Optional[float] = None
+    techManipulation: Optional[float] = None
+
 
 @dataclass_json
 @dataclass
@@ -71,17 +86,22 @@ class EmissionsBreakdown:
     framework: str
     totals: EmissionsTotals
 
+
 @dataclass_json
 @dataclass
 class AdFormatCoverage:
     name: str
     value: str
-    verified: bool
+    vendor: Optional[str] = None
+    verified: Optional[bool] = None
+
 
 @dataclass_json
 @dataclass
 class SimpleValue:
     value: str
+    verified: Optional[bool] = None
+
 
 @dataclass_json
 @dataclass
@@ -90,34 +110,43 @@ class Impressions:
     processed: int
     skipped: int
 
+
 @dataclass_json
 @dataclass
 class SupplyGraphDepth:
-    averageDepth: float
-    maxDepth: int
-    minDepth: int
+    averageDepth: Optional[float] = None
+    maxDepth: Optional[int] = None
+    minDepth: Optional[int] = None
+
 
 @dataclass_json
 @dataclass
 class SupplyGraph:
     logical: SupplyGraphDepth
     technical: SupplyGraphDepth
-    totalCount: int
+    totalCount: Optional[int] = None
+
 
 @dataclass_json
 @dataclass
 class RowCoverage:
-    adFormat: AdFormatCoverage
-    channel: SimpleValue
     impressions: Impressions
-    property: SimpleValue
-    supplyGraph: SupplyGraph
+    adFormat: Optional[AdFormatCoverage] = None
+    channel: Optional[SimpleValue] = None
     compensationProvider: Optional[SimpleValue] = None
+    inventoryClassification: Optional[SimpleValue] = None
+    mediaOwner: Optional[SimpleValue] = None
+    property: Optional[SimpleValue] = None
+    seller: Optional[SimpleValue] = None
+    supplyGraph: Optional[SupplyGraph] = None
+    venueCategory: Optional[SimpleValue] = None
+
 
 @dataclass_json
 @dataclass
 class EmissionsComponent:
     emissions: float
+
 
 @dataclass_json
 @dataclass
@@ -125,10 +154,12 @@ class CompensationBreakdown:
     emissions: float
     provider: str
 
+
 @dataclass_json
 @dataclass
 class CompensatedBreakdownStruct:
     compensation: CompensationBreakdown
+
 
 @dataclass_json
 @dataclass
@@ -136,17 +167,21 @@ class Compensated:
     breakdown: CompensatedBreakdownStruct
     total: float
 
+
 @dataclass_json
 @dataclass
 class SimpleBreakdown:
-    adPlatform: EmissionsComponent
-    dataTransfer: EmissionsComponent
+    adPlatform: Optional[EmissionsComponent] = None
+    dataTransfer: Optional[EmissionsComponent] = None
+
 
 @dataclass_json
 @dataclass
 class MediaDistributionBreakdown:
-    corporate: EmissionsComponent
-    dataTransfer: EmissionsComponent
+    corporate: Optional[EmissionsComponent] = None
+    dataTransfer: Optional[EmissionsComponent] = None
+    storageAndTransport: Optional[EmissionsComponent] = None
+
 
 @dataclass_json
 @dataclass
@@ -154,25 +189,37 @@ class ComponentWithBreakdown:
     breakdown: SimpleBreakdown
     total: float
 
+
 @dataclass_json
 @dataclass
 class MediaDistributionComponent:
     breakdown: MediaDistributionBreakdown
     total: float
 
+
 @dataclass_json
 @dataclass
 class RowEmissionsBreakdownDetail:
-    adSelection: ComponentWithBreakdown
-    compensated: Compensated
-    creativeDelivery: ComponentWithBreakdown
-    mediaDistribution: MediaDistributionComponent
+    adSelection: Optional[ComponentWithBreakdown] = None
+    compensated: Optional[Compensated] = None
+    creativeDelivery: Optional[ComponentWithBreakdown] = None
+    disposal: Optional[ComponentWithBreakdown] = None
+    mediaDistribution: Optional[MediaDistributionComponent] = None
+    techManipulation: Optional[ComponentWithBreakdown] = None
+
 
 @dataclass_json
 @dataclass
 class RowEmissionsBreakdown:
     breakdown: RowEmissionsBreakdownDetail
     framework: str
+
+
+@dataclass_json
+@dataclass
+class Error:
+    message: str
+
 
 @dataclass_json
 @dataclass
@@ -183,6 +230,7 @@ class PolicyEvaluationData:
     channel: str
     channelStatus: str
     benchmarksPercentile: int
+
 
 @dataclass_json
 @dataclass
@@ -199,27 +247,31 @@ class Internal:
     isMFA: bool
     policyEvaluationData: PolicyEvaluationData
 
+
 @dataclass_json
 @dataclass
 class Row:
-    coverage: RowCoverage
-    emissionsBreakdown: RowEmissionsBreakdown
     inventoryCoverage: str
-    policies: List[RowPolicy]
-    rowIdentifier: str
-    totalEmissions: float
-    internal: Internal
+    coverage: Optional[RowCoverage] = None
+    emissionsBreakdown: Optional[RowEmissionsBreakdown] = None
+    error: Optional[Error] = None
+    internal: Optional[Internal] = None
+    policies: Optional[List[RowPolicy]] = None
+    rowIdentifier: Optional[str] = None
+    totalEmissions: Optional[float] = None
+
 
 @dataclass
 class MeasureResponse(DataClassJsonMixin):
-    coverage: Coverage
-    policies: List[Policy]
-    requestId: str
     totalEmissions: float
     totalEmissionsBreakdown: EmissionsBreakdown
-    rows: List[Row]
+    coverage: Optional[Coverage] = None
+    policies: Optional[List[Policy]] = None
+    requestId: Optional[str] = None
+    rows: Optional[List[Row]] = None
 
     def __str__(self) -> str:
+        print(json.dumps(self.to_dict(), indent=2))
         return (
             f"RequestID: {self.requestId}\n"
             f"Total Emissions: {self.totalEmissions:.4f}\n"


### PR DESCRIPTION
## Summary

- Fixes deserialization failures in `api/response.py` where fields optional per the OpenAPI spec were typed as required, causing crashes when the API response omits them
- Adds fields that exist in the spec but were entirely absent from the dataclasses
- Marks the non-spec `internal` field on `Row` as `Optional` so responses without it don't throw

## Fields changed to `Optional`

| Dataclass | Fields |
|---|---|
| `MeasureResponse` | `requestId`, `coverage`, `policies`, `rows` |
| `Coverage` | `adFormats`, `channels`, `mediaOwners`, `properties`, `sellers` |
| `Row` | `coverage`, `emissionsBreakdown`, `policies`, `rowIdentifier`, `totalEmissions`, `internal` |
| `RowCoverage` | `adFormat`, `channel`, `property`, `supplyGraph` |
| `SupplyGraph` | `totalCount` |
| `SupplyGraphDepth` | `averageDepth`, `maxDepth`, `minDepth` |
| `AdFormatCoverage` | `verified` |
| `EmissionsTotals` | `adSelection`, `creativeDelivery`, `mediaDistribution` |
| `RowEmissionsBreakdownDetail` | `adSelection`, `compensated`, `creativeDelivery`, `mediaDistribution` |
| `SimpleBreakdown` | `adPlatform`, `dataTransfer` |
| `MediaDistributionBreakdown` | `corporate`, `dataTransfer` |

## Missing fields added

| Dataclass | Field | Type |
|---|---|---|
| `Row` | `error` | `Optional[Error]` (new `Error` dataclass) |
| `RowCoverage` | `seller`, `mediaOwner`, `venueCategory`, `inventoryClassification` | `Optional[SimpleValue]` |
| `AdFormatCoverage` | `vendor` | `Optional[str]` |
| `SimpleValue` | `verified` | `Optional[bool]` |
| `EmissionsTotals` | `compensated`, `techManipulation`, `disposal` | `Optional[float]` |
| `RowEmissionsBreakdownDetail` | `techManipulation`, `disposal` | `Optional[ComponentWithBreakdown]` |
| `MediaDistributionBreakdown` | `storageAndTransport` | `Optional[EmissionsComponent]` |
| `BaseMetric` | `verifiedRate` | `Optional[float]` |